### PR TITLE
style: breadcrumb 컴포넌트 css 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
@@ -27,11 +28,11 @@ export default function Home() {
       <Breadcrumb>
         <BreadcrumbList>
           <BreadcrumbItem>
-            <Link href="/">홈</Link>
+            <BreadcrumbLink href="/">홈</BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
-            <Link href="/components">하위 페이지</Link>
+            <BreadcrumbLink href="/components">하위 페이지</BreadcrumbLink>
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -17,7 +17,7 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
     <ol
       ref={ref}
       className={cn(
-        'flex flex-wrap items-center gap-1.5 break-words text-sm text-neutral-500 sm:gap-2.5 dark:text-neutral-400',
+        'w-[1200px] py-4 px-6 flex flex-wrap items-center break-words text-sm text-neutral-500 sm:gap-2.5 dark:text-neutral-400',
         className,
       )}
       {...props}
@@ -31,7 +31,7 @@ const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWitho
     <li
       ref={ref}
       className={cn(
-        'inline-flex items-center gap-1.5 text-link-small-desktop font-[400] text-neutral-80',
+        'inline-flex items-center gap-3 text-link-small-desktop font-[400] text-neutral-80',
         className,
       )}
       {...props}
@@ -51,10 +51,7 @@ const BreadcrumbLink = React.forwardRef<
   return (
     <Comp
       ref={ref}
-      className={cn(
-        'transition-colors hover:text-neutral-950 dark:hover:text-neutral-50',
-        className,
-      )}
+      className={cn('text-[14px] font-[400] leading-[160%] text-neutral-50', className)}
       {...props}
     />
   );
@@ -79,7 +76,7 @@ const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentP
   <li
     role="presentation"
     aria-hidden="true"
-    className={cn('[&>svg]:w-6 [&>svg]:h-6 py-[24px] px-[8px]', className)}
+    className={cn('[&>svg]:w-6 [&>svg]:h-6 py-[24px] px-[8px] text-neutral-50', className)}
     {...props}
   >
     {children ?? <ChevronRight />}

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { ChevronRight, MoreHorizontal } from 'lucide-react';
-
 import { cn } from '@/lib/utils';
 
 const Breadcrumb = React.forwardRef<
@@ -16,10 +15,7 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
   ({ className, ...props }, ref) => (
     <ol
       ref={ref}
-      className={cn(
-        'w-[1200px] py-4 px-6 flex flex-wrap items-center break-words text-sm text-neutral-500 sm:gap-2.5 dark:text-neutral-400',
-        className,
-      )}
+      className={cn('w-[1200px] py-4 px-6 flex flex-wrap items-center', className)}
       {...props}
     />
   ),


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

## List any relevant issue numbers(selected):

### example issue

## Description

- breadcrumb 컴포넌트 css 수정했습니다.

### Screen(selected)

## Summary by Sourcery

브레드크럼 컴포넌트의 스타일을 업데이트합니다.

새로운 기능:
- 브레드크럼 링크를 `<BreadcrumbLink>` 컴포넌트로 감쌉니다.

개선 사항:
- 브레드크럼 컴포넌트의 간격, 글꼴 크기, 색상을 조정하여 시각적 매력과 가독성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the styling of the breadcrumb component.

New Features:
- Wrap the breadcrumb links with `<BreadcrumbLink>` component.

Enhancements:
- Adjust the spacing, font size, and colors of the breadcrumb component to improve visual appeal and readability.

</details>