### PR TITLE
refactor : Icon 라이브러리로 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { IconBellFilled, IconSearch, IconUserFilled } from "@tabler/icons-react";
 import Image from "next/image";
 
 export default function Header() {
@@ -14,13 +15,13 @@ export default function Header() {
       <div>
         <ul className="flex gap-4">
           <li className="flex justify-center items-center w-10 h-10 bg-neutral-80 rounded-full hover:cursor-pointer hover:bg-neutral-70 active:bg-neutral-50">
-            <Image width={24} height={24} src={"icons/active/search-bold.svg"} alt="헤더아이콘" className="filter invert" />
+            <IconSearch className="text-neutral-0" />
           </li>
           <li className="flex justify-center items-center w-10 h-10 bg-neutral-80 rounded-full hover:cursor-pointer hover:bg-neutral-70 active:bg-neutral-50">
-            <Image width={24} height={24} src={"icons/gnb/bell-filled.svg"} alt="헤더아이콘" className="filter invert" />
+            <IconBellFilled className="text-neutral-0" />
           </li>
           <li className="flex justify-center items-center w-10 h-10 bg-neutral-80 rounded-full hover:cursor-pointer hover:bg-neutral-70 active:bg-neutral-50">
-            <Image width={24} height={24} src={"icons/gnb/user-filled.svg"} alt="헤더아이콘" className="filter invert" />
+            <IconUserFilled className="text-neutral-0" />
           </li>
         </ul>
       </div>

--- a/src/components/SideBar/SideBarFavoriteCertifications.tsx
+++ b/src/components/SideBar/SideBarFavoriteCertifications.tsx
@@ -1,5 +1,7 @@
 'use client';
+
 import { useState } from "react";
+import { IconBell, IconCalendar, IconHome, IconSettings, IconVocabulary } from "@tabler/icons-react";
 import SideBarLi from "./SideBarLi";
 import SideBarLogo from "./SideBarLogo";
 
@@ -18,16 +20,16 @@ export default function SideBarFavoriteCertifications() {
         <div>
           <SideBarLogo isCollapsed={isCollapsed} toggleSidebar={toggleSidebar} />
           <ul className="flex flex-col justify-center items-center text-neutral-0">
-            <SideBarLi iconUrl={"/icons/study/home.svg"} iconName={"My Home"} liName={"My 홈"} isCollapsed={isCollapsed} />
-            <SideBarLi iconUrl={"/icons/study/vocabulary.svg"} iconName={"관심자격증"} liName={"관심자격증"} isCollapsed={isCollapsed} />
-            <SideBarLi iconUrl={"/icons/study/calendar-month.svg"} iconName={"자격증모아보기"} liName={"자격증모아보기"} isCollapsed={isCollapsed} />
+            <SideBarLi liName={"My 홈"} isCollapsed={isCollapsed} Icon={IconHome} />
+            <SideBarLi liName={"관심자격증"} isCollapsed={isCollapsed} Icon={IconVocabulary} />
+            <SideBarLi liName={"자격증모아보기"} isCollapsed={isCollapsed} Icon={IconCalendar} />
           </ul>
 
         </div>
 
         <ul className="flex flex-col justify-center items-center text-neutral-0">
-          <SideBarLi iconUrl={"/icons/gnb/bell-filled.svg"} iconName={"알림설정"} liName={"알림설정"} isCollapsed={isCollapsed} />
-          <SideBarLi iconUrl={"/icons/active/settings.svg"} iconName={"설정"} liName={"설정"} isCollapsed={isCollapsed} />
+          <SideBarLi liName={"알림설정"} isCollapsed={isCollapsed} Icon={IconBell} />
+          <SideBarLi liName={"설정"} isCollapsed={isCollapsed} Icon={IconSettings} />
         </ul>
 
       </nav>

--- a/src/components/SideBar/SideBarLi.tsx
+++ b/src/components/SideBar/SideBarLi.tsx
@@ -1,16 +1,15 @@
-import Image from "next/image";
+import { IconAbc } from "@tabler/icons-react";
 
 type SideBarIcon = {
-  iconUrl: string,
-  iconName: string,
   liName: string,
   isCollapsed: boolean
+  Icon: React.ElementType
 }
 
-export default function SideBarLi({ iconUrl, iconName, liName, isCollapsed }: SideBarIcon) {
+export default function SideBarLi({ liName, isCollapsed, Icon }: SideBarIcon) {
   return (
     <li className={`flex items-center ${isCollapsed ? "justify-center px-4 py-4" : "w-[90%] px-5 py-4 gap-4 "} hover:cursor-pointer hover:bg-neutral-70 hover:rounded-full active:bg-neutral-0 active:text-neutral-85`}>
-      <Image width={24} height={24} src={iconUrl} alt={iconName} className="filter invert " />
+      <Icon className="text-neutral-0" />
       <span className={isCollapsed ? "hidden" : ""}>{liName}</span>
     </li>
   );

--- a/src/components/SideBar/SideBarLogo.tsx
+++ b/src/components/SideBar/SideBarLogo.tsx
@@ -1,3 +1,4 @@
+import { IconArrowBarLeft, IconArrowBarRight } from "@tabler/icons-react";
 import Image from "next/image";
 
 type SideBarLogoType = {
@@ -10,7 +11,11 @@ function SideBarLogo({ isCollapsed, toggleSidebar }: SideBarLogoType) {
     <div className={`${isCollapsed ? "relative p-5" : " p-7"} flex justify-between items-center`}>
       <Image width={`${isCollapsed ? "40" : "157"}`} height={40} src={`${isCollapsed ? "/logos/logo-light.svg" : "/logos/logo-text-light.svg"}`} alt="로고" />
       <div className={`${isCollapsed ? "w-8 h-8 p-2 absolute top-16 -right-4 bg-neutral-80 rounded-full" : ""} hover:cursor-pointer`}>
-        <Image width={24} height={24} src={`${isCollapsed ? "/icons/direction/bar-right.svg" : "/icons/direction/bar-left.svg"}`} alt="화살표" className="filter invert" onClick={toggleSidebar} />
+        {isCollapsed ? (
+          <IconArrowBarRight className="text-neutral-0" onClick={toggleSidebar} />
+        ) : (
+          <IconArrowBarLeft className="text-neutral-0" onClick={toggleSidebar} />
+        )}
       </div>
     </div>
   );

--- a/src/components/SideBar/SideBarMyHome.tsx
+++ b/src/components/SideBar/SideBarMyHome.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState } from "react";
+import { IconBookmark, IconGraph, IconHome, IconMessageCircle, IconSettings } from "@tabler/icons-react";
 import SideBarLi from "./SideBarLi";
 import SideBarLogo from "./SideBarLogo";
 
@@ -18,15 +19,15 @@ export default function SideBarMyHome() {
         <div>
           <SideBarLogo isCollapsed={isCollapsed} toggleSidebar={toggleSidebar} />
           <ul className="flex flex-col justify-center items-center text-neutral-0">
-            <SideBarLi iconUrl={"/icons/state/message-circle.svg"} iconName={"커뮤니티"} liName={"커뮤니티"} isCollapsed={isCollapsed} />
-            <SideBarLi iconUrl={"/icons/active/graph.svg"} iconName={"내활동"} liName={"내활동"} isCollapsed={isCollapsed} />
-            <SideBarLi iconUrl={"/icons/react/bookmark-line.svg"} iconName={"저장됨"} liName={"저장됨"} isCollapsed={isCollapsed} />
+            <SideBarLi liName={"커뮤니티"} isCollapsed={isCollapsed} Icon={IconMessageCircle} />
+            <SideBarLi liName={"내활동"} isCollapsed={isCollapsed} Icon={IconGraph} />
+            <SideBarLi liName={"저장됨"} isCollapsed={isCollapsed} Icon={IconBookmark} />
           </ul>
 
         </div>
 
         <ul className="flex flex-col justify-center items-center text-neutral-0">
-          <SideBarLi iconUrl={"/icons/active/settings.svg"} iconName={"설정"} liName={"설정"} isCollapsed={isCollapsed} />
+          <SideBarLi liName={"설정"} isCollapsed={isCollapsed} Icon={IconSettings} />
         </ul>
 
       </nav>


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [X] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected): #48


## Description

- 아이콘들 다 바꾸어 놓았습니다!!!!!

### Screen(selected)

## Summary by Sourcery

기존 아이콘을 전용 아이콘 라이브러리의 아이콘으로 대체합니다.

개선 사항:
- `SideBar` 컴포넌트를 아이콘 라이브러리의 아이콘을 사용하도록 업데이트했습니다.
- `Header` 컴포넌트를 아이콘 라이브러리의 아이콘을 사용하도록 업데이트했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace the existing icons with icons from a dedicated icon library.

Enhancements:
- Updated the `SideBar` component to use icons from an icon library.
- Updated the `Header` component to use icons from an icon library.

</details>