### PR TITLE
refactor: BtnOnboarding 사이즈 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -136,8 +136,10 @@ export default function Home() {
         </div>
       </div>
       <div className="flex gap-9">
-        <BtnOnboarding type={'general'} />
-        <BtnOnboarding type={'specific'} />
+        <BtnOnboarding type={'general'} size={'large'} />
+        <BtnOnboarding type={'general'} size={'medium'} />
+        <BtnOnboarding type={'specific'} size={'large'} />
+        <BtnOnboarding type={'specific'} size={'medium'} />
       </div>
       <StudyCard />
       <div className="flex gap-3">

--- a/src/components/Onboarding/BtnOnboarding.tsx
+++ b/src/components/Onboarding/BtnOnboarding.tsx
@@ -3,9 +3,10 @@ import Link from 'next/link';
 
 type BtnOnboardingProps = {
   type: 'general' | 'specific';
+  size: 'large' | 'medium';
 };
 
-export default function BtnOnboarding({ type }: BtnOnboardingProps) {
+export default function BtnOnboarding({ type, size }: BtnOnboardingProps) {
   const templates = {
     general: {
       imageSrc: '/images/general.png',
@@ -24,18 +25,26 @@ export default function BtnOnboarding({ type }: BtnOnboardingProps) {
   };
 
   const { imageSrc, altText, description, title, link } = templates[type];
-
+  const isLarge = size === 'large';
   return (
     <Link href={link}>
-      <button className="group w-[400px] h-[490px] bg-neutral-0 shadow-2 rounded-9 pb-7 border-2 border-transparent transition duration-300 hover:border-neutral-20 active:bg-neutral-85">
+      <button
+        className={`group ${isLarge ? 'w-[400px] h-[490px]' : 'w-[330px] h-[404px]'} bg-neutral-0 shadow-2 rounded-9 pb-7 border-2 border-transparent transition duration-300 hover:border-neutral-20 active:bg-neutral-85`}
+      >
         <div className="flex flex-col items-center">
-          <img src={imageSrc} alt={altText} className="size-[263px]" />
+          <img
+            src={imageSrc}
+            alt={altText}
+            className={`${isLarge ? 'size-[263px]' : 'size-[200px]'}`}
+          />
           <div className="flex flex-col items-center gap-5">
-            <p className="text-body-medium-desktop text-neutral-50 transition duration-300 group-active:text-neutral-10">
+            <p
+              className={`${isLarge ? 'text-body-medium-desktop' : 'text-body-xsmall-desktop'} text-neutral-50 transition duration-300 group-active:text-neutral-10`}
+            >
               {description}
             </p>
             <p
-              className="text-title-large-desktop text-neutral-90 transition duration-300 group-active:text-neutral-0"
+              className={`${isLarge ? 'text-title-large-desktop' : 'text-title-medium-desktop'}  text-neutral-90 transition duration-300 group-active:text-neutral-0`}
               dangerouslySetInnerHTML={{ __html: title }}
             />
           </div>


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- BtnOnboarding 사이즈(large, medium) 추가

### Screen(selected)

## Summary by Sourcery

새로운 기능:
- 사용자가 BtnOnboarding 컴포넌트를 대형(large)과 중형(medium) 두 가지 크기로 렌더링할 수 있도록 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Allow users to render the BtnOnboarding component in two different sizes: large and medium.

</details>