### PR TITLE
refactor: 아이콘 선택 여부 추가, 레이블 추가, 만일을 대비해 텍스트 크기와 텍스트 색상 별도 옵션 추가

### DIFF
--- a/src/app/mypage/account-info/MyInfo.tsx
+++ b/src/app/mypage/account-info/MyInfo.tsx
@@ -112,8 +112,12 @@ const MyInfo = () => {
       <div className="flex flex-col gap-5">
         <p className="flex justify-end text-red-40">계정 삭제하기</p>
         <div className="flex gap-5">
-          <Button className="h-[61px] w-full">돌아가기</Button>
-          <Button className="h-[61px] w-full">저장하기</Button>
+          <Button className="w-full" variant="third" size="lg">
+            돌아가기
+          </Button>
+          <Button className="w-full" variant="secondary" size="lg">
+            저장하기
+          </Button>
         </div>
       </div>
     </div>

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -203,6 +203,8 @@ export default function Home() {
       <Button variant="secondary" size="lg" className="font-medium">
         라지 박스
       </Button>
+      <Button variant="secondary" size="lg" className="font-medium" label="라지박스" />
+
       <Button variant="secondary" size="md" className="ga text-neutral-80">
         미디움 박스
       </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,6 +3,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
+// todo: 버튼에 들어갈 아이콘 확인 후 필요한 것만 항목 추가할 것.
 const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap ring-offset-white transition-colors  disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300',
   {
@@ -13,27 +14,40 @@ const buttonVariants = cva(
         secondary:
           'w-[136px] text-neutral-0 !text-neutral-0 font-medium bg-neutral-85 hover:bg-neutral-80 active:bg-neutral-70 disabled:bg-neutral-5 disabled:text-neutral-20  disabled:!text-neutral-20 text-label-large-desktop gap-3',
         third:
-          'text-neutral-80 bg-neutral-5 font-medium hover:bg-neutral-10 active:bg-neutral-20 disabled:bg-neutral-5 disabled:text-neutral-20 text-label-large-desktop gap-[10px]',
+          'text-neutral-80 bg-neutral-10 font-medium hover:bg-neutral-20 active:bg-neutral-20 disabled:bg-neutral-5 disabled:text-neutral-20 text-label-large-desktop gap-[10px]',
         outline:
           'text-neutral-80 border border-neutral-20 bg-neutral-0 font-medium hover:bg-neutral-5 active:bg-neutral-10 disabled:bg-neutral-5 disabled:text-neutral-20 text-label-large-desktop',
         text: 'text-neutral-80 font-medium hover:font-bold disabled:text-neutral-20',
-        link: '',
-        ghost: '',
+        round: 'rounded-10',
+        // 링크, 기타 버튼에 사용되는 항목
+        none: '',
       },
       size: {
         default: '',
-        sm: 'rounded-3 px-[16px] py-[8px]',
-        md: 'rounded-4 px-[24px] py-[12px]',
-        lg: 'rounded-4 px-[32px] py-[16px]',
-        text_sm: 'p-3 gap-[10px] text-label-small-desktop',
-        text_md: 'p-3 gap-[10px] text-label-medium-desktop',
-        text_lg: 'p-3 gap-[10px] text-label-large-desktop',
+        sm: 'rounded-3 px-[16px] py-[8px] gap-[10px] text-label-small-desktop',
+        md: 'rounded-4 px-[24px] py-[12px] gap-[10px] text-label-medium-desktop',
+        lg: 'rounded-4 px-[32px] py-[16px] gap-[10px] text-label-large-desktop',
         icon: 'h-10 w-10',
+      },
+      // 텍스트 사이즈만
+      textSize: {
+        default: '',
+        sm: 'text-label-small-desktop',
+        md: 'text-label-medium-desktop',
+        lg: 'text-label-large-desktop',
+      },
+      textColor: {
+        default: '',
+        dark: 'text-neutral-80',
+        gray: 'text-neutral-20',
+        strong: 'text-neutral-80 font-[800]',
       },
     },
     defaultVariants: {
       variant: 'default',
       size: 'default',
+      textSize: 'default',
+      textColor: 'default',
     },
   },
 );
@@ -42,16 +56,21 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  withIcon?: boolean;
+  label?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, children, ...props }, ref) => {
+  (
+    { className, variant, size, asChild = false, children, withIcon = false, label, ...props },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : 'button';
     const iconSize = size === 'sm' ? '16px' : '20px';
 
     return (
       <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props}>
-        {variant === 'secondary' && (
+        {withIcon === true && (
           <img
             src="/icons/active/check.svg"
             alt="button icon"
@@ -60,7 +79,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             height={iconSize}
           />
         )}
-        {children}
+        {label || children}
       </Comp>
     );
   },


### PR DESCRIPTION
## This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

## List any relevant issue numbers(selected):

### example issue

## Description

- 페이지 디자인 검토 결과, 버튼에 텍스트와 아이콘을 함께 사용한 부분이 아직 보이지 않아 기존 버튼(variant='secondary')에서 아이콘 등장 여부를 삭제하고, 대신 withIcon이라는 항목을 만들어 필요한 경우 별도로 추가할 수 있게 해두었습니다.
- label 항목을 추가해 텍스트만 작성하는 것으로 충분한 버튼을 코드에서 조금 더 간결하게 표현할 수 있게 했습니다.

### Screen(selected)

## Sourcery 요약

Button 컴포넌트의 유연성과 재사용성을 향상시키기 위해 리팩토링합니다. 아이콘 가시성을 제어하는 `withIcon` prop, 단순화된 텍스트 렌더링을 위한 `label` prop, 텍스트 크기 및 색상에 대한 별도의 옵션을 도입합니다.

개선 사항:
- Button 컴포넌트에 아이콘 표시를 명시적으로 제어할 수 있는 `withIcon` prop을 추가합니다.
- 텍스트만 있는 버튼 구현을 더 깔끔하게 하기 위해 Button 컴포넌트에 `label` prop을 추가합니다.
- 보다 세분화된 텍스트 스타일 제어를 위해 `textSize` 및 `textColor` variant를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactors the Button component to improve flexibility and reusability. It introduces a `withIcon` prop to control icon visibility, a `label` prop for simplified text rendering, and separate options for text size and color.

Enhancements:
- Adds `withIcon` prop to the Button component to allow explicit control over icon display.
- Adds a `label` prop to the Button component for cleaner text-only button implementations.
- Introduces `textSize` and `textColor` variants for more granular text styling control.

</details>